### PR TITLE
Added image previews for assets in the list

### DIFF
--- a/VirtoCommerce.ContentModule.Tests/PermalinkTests.cs
+++ b/VirtoCommerce.ContentModule.Tests/PermalinkTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.ContentModule.Utils;
 using Xunit;
 
@@ -19,7 +17,7 @@ namespace VirtoCommerce.ContentModule.Tests
             {
                 FilePath = @"/temp/foobar_baz.md",
             };
-        
+
             var url = fmPermalink.ToUrl();
             Assert.Equal("temp/foobar_baz", url);
         }
@@ -64,7 +62,7 @@ namespace VirtoCommerce.ContentModule.Tests
         [InlineData("/:dashcategories/:year/:month/:day/:title.html", "/2015/03/09/foobar-baz.html", "")]
         [InlineData("pretty", "temp/cat1/cat2/2015/03/09/foobar-baz/", "cat1,cat2")]
         [InlineData("ordinal", "temp/cat1/cat2/2015/068/foobar-baz", "cat1,cat2")]
-        [InlineData("none", "temp/cat1/cat2/foobar-baz", "cat1,cat2")]
+        [InlineData("default", "temp/cat1/cat2/foobar-baz", "cat1,cat2")]
         [InlineData("/:categories/:short_year/:i_month/:i_day/:title.html", "/cat1/cat2/15/3/9/foobar-baz.html", "cat1,cat2")]
         [InlineData("/:category/:title.html", "/cat1/foobar-baz.html", "cat1,cat2")]
         [InlineData("/:category/:title.html", "/foobar-baz.html", "")]

--- a/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-list.js
+++ b/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-list.js
@@ -17,7 +17,7 @@
                 _.each(data, function (x) {
                     x.isImage = x.mimeType && x.mimeType.startsWith('image/');
                     if (x.isImage){
-                        x.noCacheUrl = x.url + (x.url.indexOf('?') > -1 ? '&t=' : '?t=') + x.modifiedDate;
+                        x.noCacheUrl = x.url;
                     }
                     x.isOpenable = x.mimeType && (x.mimeType.startsWith('application/j') || x.mimeType.startsWith('text/'));
                 });

--- a/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-list.js
+++ b/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-list.js
@@ -16,6 +16,9 @@
                 $scope.pageSettings.totalItems = data.length;
                 _.each(data, function (x) {
                     x.isImage = x.mimeType && x.mimeType.startsWith('image/');
+                    if (x.isImage){
+                        x.noCacheUrl = x.url + (x.url.indexOf('?') > -1 ? '&t=' : '?t=') + x.modifiedDate;
+                    }
                     x.isOpenable = x.mimeType && (x.mimeType.startsWith('application/j') || x.mimeType.startsWith('text/'));
                 });
                 $scope.listEntries = data;
@@ -51,7 +54,7 @@
 
             var isFolder = /\/$/.test(listItem.url);
             var result = prompt("Enter new name", listItem.name);
-            // if rename folder, then ulr name ends '/' 
+            // if rename folder, then ulr name ends '/'
             var substrNameLenght = isFolder ? listItem.name.length + 1 : listItem.name.length;
 
             if (result) {


### PR DESCRIPTION
#9 
Content module uses [asset-list.tpl.html](https://github.com/VirtoCommerce/vc-platform/blob/master/VirtoCommerce.Platform.Web/Scripts/app/assets/blades/asset-list.tpl.html) from the platform to show the list of assets.

[asset-list.tpl.html](https://github.com/VirtoCommerce/vc-platform/blob/master/VirtoCommerce.Platform.Web/Scripts/app/assets/blades/asset-list.tpl.html#L74-L75) expects `noCacheUrl` to render an image and uses FontAwesome icons for folder and blank file icon for all other files.

I added `noCacheUrl` property to assets according to the [example](https://github.com/VirtoCommerce/vc-platform/blob/master/VirtoCommerce.Platform.Web/Scripts/app/assets/blades/asset-list.js#L21-L23) in Platform to show the image previews.

To show different icons for other mime-types we need to either change platform's [asset-list.tpl.hml](https://github.com/VirtoCommerce/vc-platform/blob/master/VirtoCommerce.Platform.Web/Scripts/app/assets/blades/asset-list.tpl.html) or copy-paste it to this module and enhance it. Let's decide?

![imageassets](https://user-images.githubusercontent.com/3872761/49616284-94c07000-f9b0-11e8-991b-873a32b0d992.gif)
