### PR TITLE
VP-2060: Button create on "Create page" blade

### DIFF
--- a/src/VirtoCommerce.ContentModule.Web/Scripts/blades/pages/page-detail.tpl.html
+++ b/src/VirtoCommerce.ContentModule.Web/Scripts/blades/pages/page-detail.tpl.html
@@ -1,4 +1,4 @@
-﻿<div class="blade-static __expanded">
+<div class="blade-static __expanded">
     <form class="form" name="formScope">
         <div class="columns clearfix">
             <div class="column">
@@ -40,7 +40,7 @@
                     <div class="tab-item">{{ 'content.blades.edit-page.labels.metadata' | translate }}</div>
                 </div>
                 <div class="tab-cnt __opened">
-                    <form class="form" name="formScope">
+                    <form class="form">
                         <input id="fileUploader" type="file" multiple style="display: none;" uploader="fileUploader" nv-file-select />
                         <textarea vc-uk-htmleditor ng-model="blade.currentEntity.content" file-uploader="fileUploader"></textarea>
                     </form>


### PR DESCRIPTION
### Problem
The button "Create" is active when form is not valid

### Solution
Button "Create" should no to be active until form won't be valid.

### Proposed of changes
Remove redundant form name

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
