### PR TITLE
VP-2070: Fix form scope for assets details

### DIFF
--- a/src/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-detail.tpl.html
+++ b/src/VirtoCommerce.ContentModule.Web/Scripts/blades/themes/asset-detail.tpl.html
@@ -1,6 +1,6 @@
-﻿<div class="blade-static __expanded" ng-if="blade.isNew">
-    <form name="formScope">
-        <div class="form-group" ng-init="setForm(formScope)">
+<form name="formScope" ng-init="setForm(formScope)">
+    <div class="blade-static __expanded" ng-if="blade.isNew">
+        <div class="form-group">
             <label class="form-label">{{ 'content.blades.edit-asset.labels.asset-name' | translate }}</label>
             <div class="form-input">
                 <input focus-on="" required class="form-control" ng-model="blade.currentEntity.name" placeholder="{{ 'content.blades.edit-asset.placeholders.asset-name' | translate }}" name="name" ui-validate=" 'validators.webSafeFileNameValidator($value)' " />
@@ -9,24 +9,25 @@
                 <span ng-show="formScope.name.$error.validator">{{ 'content.blades.edit-asset.validations.name-invalid' | translate }}</span>
             </div>
         </div>
-    </form>
-</div>
-<div class="blade-static __collapsed" ng-if="!blade.isNew">
-    <div class="form-group">
-        <label>{{blade.currentEntity.name}}</label> | <a href="http://docs.virtocommerce.com/display/vc2devguide/Liquid+Reference" target="_blank">{{ 'content.blades.edit-asset.labels.liquid-documentation' | translate }}</a>
     </div>
-</div>
-<div class="blade-static __bottom" ng-include="'$(Platform)/Scripts/common/templates/create.tpl.html'" ng-if="blade.isNew"></div>
-<div class="blade-content __xxlarge-wide">
-    <div class="blade-inner">
-        <div class="inner-block">
-            <form class="form" name="formScope">
+
+    <div class="blade-static __collapsed" ng-if="!blade.isNew">
+        <div class="form-group">
+            <label>{{blade.currentEntity.name}}</label> | <a href="http://docs.virtocommerce.com/display/vc2devguide/Liquid+Reference" target="_blank">{{ 'content.blades.edit-asset.labels.liquid-documentation' | translate }}</a>
+        </div>
+    </div>
+
+    <div class="blade-static __bottom" ng-include="'$(Platform)/Scripts/common/templates/create.tpl.html'" ng-if="blade.isNew"></div>
+
+    <div class="blade-content __xxlarge-wide">
+        <div class="blade-inner">
+            <div class="inner-block">
                 <div class="form-group">
                     <div class="form-input __expanded">
                         <ui-codemirror required ng-model="blade.currentEntity.content" ui-codemirror-opts="editorOptions"></ui-codemirror>
                     </div>
                 </div>
-            </form>
+            </div>
         </div>
     </div>
-</div>
+</form>


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/VP-2070

### Problem
Reassigning form-scope disables validations.

### Solution
Remove double form scope declaration.

### Proposed of changes
Describe the technical details of the realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in GitHub PR - files count (none of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self-descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using a newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
