### PR TITLE
VP-2045: Button "Customize theme" not working

### DIFF
--- a/src/VirtoCommerce.ContentModule.Web/Scripts/blades/content-main.tpl.html
+++ b/src/VirtoCommerce.ContentModule.Web/Scripts/blades/content-main.tpl.html
@@ -1,4 +1,4 @@
-﻿<div class="blade-static" ng-if="blade.currentEntities.length">
+<div class="blade-static" ng-if="blade.currentEntities.length">
     <div class="form-group">
         <div class="form-input __search">
             <input placeholder="{{'platform.placeholders.search-keyword' | translate }}" ng-model="blade.searchText">
@@ -37,12 +37,16 @@
                                     {{ 'content.blades.content-main.labels.preview-theme' | translate }}
                                 </a>
                             </li>
+                            <!--
                             <li class="menu-item" ng-click="blade.customizeTheme(data); $event.stopPropagation();">
                                 <a class="menu-link">
                                     <i class="menu-ico fa fa-wrench"></i>
                                     {{ 'content.blades.content-main.labels.customize-theme' | translate }}
                                 </a>
                             </li>
+                            // TODO: Uncomment when and if this feature would be impleented in page builder
+                            // TODO: After uncommenting add check for page builder installed or controller overloaded.
+                            -->
                         </ul>
                     </div>
                     <div class="tile" ng-click="blade.openThemes(data.store)">


### PR DESCRIPTION
### Problem
Theme customizing it's a page builder feature, not implemented wright now.

### Solution
Hide "customize theme" button.

### Proposed of changes
Hided button

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
