### PR TITLE
VP-3326: Fix error when try Manage just created, empty blog.

### DIFF
--- a/src/VirtoCommerce.ContentModule.Web/Controllers/Api/ContentController.cs
+++ b/src/VirtoCommerce.ContentModule.Web/Controllers/Api/ContentController.cs
@@ -306,7 +306,7 @@ namespace VirtoCommerce.ContentModule.Web.Controllers.Api
 
                     if (hasContentDispositionHeader)
                     {
-                        var fileName = contentDisposition.FileName.Value ?? contentDisposition.Name.Value.Replace("\"", string.Empty);
+                        var fileName = Path.GetFileName(contentDisposition.FileName.Value ?? contentDisposition.Name.Value.Replace("\"", string.Empty));
 
                         var targetFilePath = folderUrl + "/" + fileName;
 


### PR DESCRIPTION
### Problem
UI 404 error when admin edit just created Blog folder 

### Solution
Fix wrong name of .md file witch creates in new blogs 

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
