### PR TITLE
PT-9091: Created date in Content is not corresponding to the creation date

### DIFF
--- a/src/VirtoCommerce.ContentModule.Data/Extensions/ContentItemConverter.cs
+++ b/src/VirtoCommerce.ContentModule.Data/Extensions/ContentItemConverter.cs
@@ -19,6 +19,7 @@ namespace VirtoCommerce.ContentModule.Data.Extensions
             contentFolder.ParentUrl = blobFolder.ParentUrl;
             contentFolder.RelativeUrl = blobFolder.RelativeUrl;
             contentFolder.CreatedDate = blobFolder.CreatedDate;
+            contentFolder.ModifiedDate = blobFolder.ModifiedDate;
             contentFolder.Type = blobFolder.Type;
 
             return contentFolder;

--- a/src/VirtoCommerce.ContentModule.Web/module.manifest
+++ b/src/VirtoCommerce.ContentModule.Web/module.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Content</id>
   <version>3.205.0</version>
@@ -16,7 +16,7 @@
   <iconUrl>Modules/$(VirtoCommerce.Content)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2021 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright>
   <tags>cms menu</tags>
   <assemblyFile>VirtoCommerce.ContentModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.ContentModule.Web.Module, VirtoCommerce.ContentModule.Web</moduleType>


### PR DESCRIPTION
## Description
fix: Empty Created and Modified Date for Assets and Folders

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-9091
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Content_3.205.0-pr-116-5fc8.zip
