### PR TITLE
VCST-689: Add ContentType filter

### DIFF
--- a/src/VirtoCommerce.ContentModule.Core/Model/ContentSearchCriteria.cs
+++ b/src/VirtoCommerce.ContentModule.Core/Model/ContentSearchCriteria.cs
@@ -7,5 +7,6 @@ namespace VirtoCommerce.ContentModule.Core.Model
         public string StoreId { get; set; }
         public string CultureName { get; set; }
         public string FolderUrl { get; set; }
+        public string ContentType { get; set; }
     }
 }

--- a/src/VirtoCommerce.ContentModule.Data/Search/ContentIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.ContentModule.Data/Search/ContentIndexDocumentBuilder.cs
@@ -33,6 +33,7 @@ namespace VirtoCommerce.ContentModule.Data.Search
             schema.AddFilterableStringAndContentString("StoreId");
             schema.AddFilterableStringAndContentString("Name");
             schema.AddFilterableStringAndContentString("CultureName");
+            schema.AddFilterableStringAndContentString("ContentType");
             return Task.CompletedTask;
         }
 

--- a/src/VirtoCommerce.ContentModule.Data/Search/ContentSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.ContentModule.Data/Search/ContentSearchRequestBuilder.cs
@@ -76,6 +76,11 @@ namespace VirtoCommerce.ContentModule.Data.Search
             {
                 result.Add(CreateTermFilter("FolderUrl", criteria.FolderUrl));
             }
+            if (!string.IsNullOrEmpty(criteria.ContentType))
+            {
+                result.Add(CreateTermFilter("ContentType", criteria.ContentType));
+            }
+
 
             return result;
         }


### PR DESCRIPTION
## Description
feat: Added ContentType filter to enable filtering by pages, blogs, and other content types. This enhancement provides users with greater flexibility and control over content retrieval, allowing them to specify the type of content they wish to access with more granularity.


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-689
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Content_3.802.0-pr-170-4370.zip
