### PR TITLE
VCST-2022: Bump YamIDotNet to the latest 16.1.3

### DIFF
--- a/src/VirtoCommerce.ContentModule.Data/VirtoCommerce.ContentModule.Data.csproj
+++ b/src/VirtoCommerce.ContentModule.Data/VirtoCommerce.ContentModule.Data.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.853.0" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.853.0" />
-    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ContentModule.Core\VirtoCommerce.ContentModule.Core.csproj" />


### PR DESCRIPTION
## Description
feat: Bump YamIDotNet to the latest 16.1.3

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2022
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Content_3.824.0-pr-191-9737.zip